### PR TITLE
Dockerfile fix to include python3 dev libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN set -ex && \
         automake \
         bzip2 \
         xsltproc \
-        gperf
+        gperf \
+        python3-dev
 
 WORKDIR /usr/local
 


### PR DESCRIPTION
Fixes build as described in #11 

Note: Docker build entrypoint points to monerod (not related to any of the current python binding work)

cc : @tiedtoastar